### PR TITLE
RFC: explicitly run garbage collection before running a sample

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -92,6 +92,7 @@ macro benchmarkable(name, setup, core, teardown)
     #   the caller might do).
     quote
         function $(esc(name))(s::Samples, nsamples, nevals)
+            gc()
             $(benchfn)(s, nsamples, nevals, $(map(esc, userargs)...))
         end
 


### PR DESCRIPTION
My thinking is that if we are close to a garbage collection when we start a new benchmark this means that allocations that happened outside the benchmark leaks into the benchmark results.